### PR TITLE
Remove unused Dispatcher import

### DIFF
--- a/macymedcacheboost/src/Controller/Admin/AdminMacymedCacheBoostDashboardController.php
+++ b/macymedcacheboost/src/Controller/Admin/AdminMacymedCacheBoostDashboardController.php
@@ -11,7 +11,6 @@ use MacymedCacheBoost\Services\ConfigurationService;
 use PrestaShopLogger;
 use Redis;
 use Context;
-use Dispatcher;
 
 class AdminMacymedCacheBoostDashboardController extends ModuleAdminController
 {


### PR DESCRIPTION
## Summary
- remove an unused Dispatcher import from the admin dashboard controller

## Testing
- `grep -n "Dispatcher" macymedcacheboost/src/Controller/Admin/AdminMacymedCacheBoostDashboardController.php`

------
https://chatgpt.com/codex/tasks/task_e_6884cc736fbc8332893e48a1f75cc6c7