### PR TITLE
Fix ConfigurationService fallback logic

### DIFF
--- a/macymedcacheboost/manual-tests/README.md
+++ b/macymedcacheboost/manual-tests/README.md
@@ -1,0 +1,19 @@
+# Manual Tests
+
+This directory contains simple scripts that verify parts of the module without requiring a full PrestaShop installation.
+
+## verify_configuration_service.php
+
+Checks the behaviour of `ConfigurationService::get()` using a stub `Configuration` class. To run the script:
+
+```bash
+php manual-tests/verify_configuration_service.php
+```
+
+Expected output:
+
+```
+string(12) "stored value"
+string(7) "default"
+string(7) "default"
+```

--- a/macymedcacheboost/manual-tests/verify_configuration_service.php
+++ b/macymedcacheboost/manual-tests/verify_configuration_service.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/../src/Services/ConfigurationService.php';
+
+use MacymedCacheBoost\Services\ConfigurationService;
+
+// Simple stub for Configuration class used by ConfigurationService
+class Configuration
+{
+    private static $data = [];
+
+    public static function get($key)
+    {
+        return self::$data[$key] ?? false;
+    }
+
+    public static function updateValue($key, $value)
+    {
+        self::$data[$key] = $value;
+    }
+
+    public static function deleteByName($key)
+    {
+        unset(self::$data[$key]);
+    }
+}
+
+Configuration::updateValue('TEST_KEY', 'stored value');
+
+// Should output 'stored value'
+var_dump(ConfigurationService::get('TEST_KEY', 'default'));
+
+Configuration::updateValue('TEST_KEY', false);
+// Should output 'default' because stored value is false
+var_dump(ConfigurationService::get('TEST_KEY', 'default'));
+
+Configuration::deleteByName('TEST_KEY');
+// Should output 'default' because value is null
+var_dump(ConfigurationService::get('TEST_KEY', 'default'));

--- a/macymedcacheboost/src/Services/ConfigurationService.php
+++ b/macymedcacheboost/src/Services/ConfigurationService.php
@@ -8,7 +8,8 @@ class ConfigurationService
 {
     public static function get($key, $default = null)
     {
-        return Configuration::get($key, null, null, $default);
+        $value = Configuration::get($key);
+        return ($value === false || $value === null) ? $default : $value;
     }
 
     public static function update($key, $value)


### PR DESCRIPTION
## Summary
- update `ConfigurationService::get()` logic
- add manual tests for verifying `ConfigurationService`

## Testing
- `php manual-tests/verify_configuration_service.php`

------
https://chatgpt.com/codex/tasks/task_e_6884cc60fe548332a3325a9e208fa412