### PR TITLE
Fix parent tab reference in CacheBoost

### DIFF
--- a/macymedcacheboost/macymedcacheboost.php
+++ b/macymedcacheboost/macymedcacheboost.php
@@ -74,7 +74,7 @@ class MacymedCacheBoost extends Module
         return false;
     }
 
-        $parentTabId = (int) Tab::getIdFromClassName('AdminParentImprove');
+        $parentTabId = (int) Tab::getIdFromClassName('IMPROVE');
         if (!$parentTabId) {
             $parentTabId = (int) Tab::getIdFromClassName('AdminParentModulesSf');
         }

--- a/macymedcacheboost/macymedcacheboost.xml
+++ b/macymedcacheboost/macymedcacheboost.xml
@@ -5,7 +5,7 @@
     <version><![CDATA[1.3.7]]></version>
     <description><![CDATA[A powerful and safe cache module for PrestaShop 8.1+.]]></description>
     <author><![CDATA[Macymed]]></author>
-    <tab><![CDATA[administration]]></tab>
+    <tab><![CDATA[IMPROVE]]></tab>
     <is_configurable>1</is_configurable>
     <need_instance>0</need_instance>
     <limited_countries></limited_countries>


### PR DESCRIPTION
## Summary
- ensure CacheBoost tab installs under Improve top-level
- align XML metadata to Improve tab

## Testing
- `php macymedcacheboost/manual-tests/verify_configuration_service.php`

------
https://chatgpt.com/codex/tasks/task_e_6884cfa60ccc8332890aa489fcb30782