### PR TITLE
Remove redundant use statements

### DIFF
--- a/macymedcacheboost/macymedcacheboost.php
+++ b/macymedcacheboost/macymedcacheboost.php
@@ -9,11 +9,6 @@ require_once __DIR__ . '/vendor/autoload.php';
 use MacymedCacheBoost\CacheManager;
 use MacymedCacheBoost\Services\CacheService;
 use MacymedCacheBoost\Services\ConfigurationService;
-use Language;
-use Tab;
-use Tools;
-use Context;
-use Configuration;
 
 class MacymedCacheBoost extends Module
 {


### PR DESCRIPTION
## Summary
- clean up `macymedcacheboost.php` by removing unnecessary `use` lines for PrestaShop classes

## Testing
- `php macymedcacheboost/manual-tests/verify_configuration_service.php`
- `php -l macymedcacheboost/macymedcacheboost.php`

------
https://chatgpt.com/codex/tasks/task_e_6884d3440e00833292fee05cca6479be