### PR TITLE
Fix mkdir in installer

### DIFF
--- a/macymedcacheboost/macymedcacheboost.php
+++ b/macymedcacheboost/macymedcacheboost.php
@@ -41,7 +41,10 @@ class MacymedCacheBoost extends Module
         try {
         $cacheDir = _PS_MODULE_DIR_ . $this->name . '/cache/';
         if (!is_dir($cacheDir)) {
-            mkdir($cacheDir, 0777, true);
+            if (!mkdir($cacheDir, 0755, true) && !is_dir($cacheDir)) {
+                $this->_errors[] = $this->l('Could not create cache directory: ') . $cacheDir;
+                return false;
+            }
         }
 
         $config_success = ConfigurationService::update('CACHEBOOST_ENABLED', true)


### PR DESCRIPTION
## Summary
- use 0755 permissions for the cache folder
- abort installation if the directory cannot be created

## Testing
- `php -l macymedcacheboost/macymedcacheboost.php`
- `composer validate --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_6884d34015908332844ef097360d738c