### PR TITLE
Add dispatcher caching hook

### DIFF
--- a/macymedcacheboost/macymedcacheboost.php
+++ b/macymedcacheboost/macymedcacheboost.php
@@ -141,7 +141,7 @@ class MacymedCacheBoost extends Module
     private function installHooks()
     {
         $hooks = [
-            // 'actionDispatcherBefore',
+            'actionDispatcherBefore',
             'actionFrontControllerBefore',
             'actionProductUpdate',
             'actionObjectProductDeleteAfter',
@@ -323,6 +323,11 @@ class MacymedCacheBoost extends Module
             ]);
             return $this->display(__FILE__, 'views/templates/admin/error.tpl');
         }
+    }
+
+    public function hookActionDispatcherBefore($params)
+    {
+        CacheManager::checkAndServeCache();
     }
 
     public function hookActionFrontControllerBefore($params)


### PR DESCRIPTION
## Summary
- register the `actionDispatcherBefore` hook during install
- handle Dispatcher hook to serve cached content

## Testing
- `php macymedcacheboost/manual-tests/verify_configuration_service.php`


------
https://chatgpt.com/codex/tasks/task_e_6884ebf551608332b924ac0f0952f8ec